### PR TITLE
Small changes to treasure.

### DIFF
--- a/Entities/Player/player.gd
+++ b/Entities/Player/player.gd
@@ -1,3 +1,4 @@
+class_name Player
 extends CharacterBody2D
 
 const MAX_SPEED = 300.0

--- a/Entities/Treasure/treasure.gd
+++ b/Entities/Treasure/treasure.gd
@@ -1,13 +1,22 @@
 extends Area2D
 
 @export var score_value := 5
-## If variance is not 0, player will gain a score_value +- variance.
+## If variance != 0, player will gain a score_value +- variance on collision.
 @export var variance := 0
+
+## If [should_randomize_appearance == true] then $AnimatedSprite2D will randomly choose one of the
+## animations listed here.
+@export var treasure_types : Array[String] = ["chest", "coin"]
+## If true, the treasure's appearance is randomized on ready. Options are listed in treasure_types.
+@export var should_randomize_appearance := true
 
 @onready var anim_player : AnimationPlayer = $AnimationPlayer
 
+
 func _ready():
-	pass # Replace with function body.
+	if should_randomize_appearance:
+		var anim_sprite : AnimatedSprite2D = $AnimatedSprite2D
+		anim_sprite.animation = treasure_types[randi() % treasure_types.size()]
 
 
 func _process(delta):
@@ -17,8 +26,9 @@ func _process(delta):
 func _on_body_entered(body):
 	if body.has_method("score_up"):
 		body.score_up(score_value + randi_range(-variance, variance))
-		anim_player.play("collected")
-		# Otherwise player may collide multiple times while the animation finishes.
+		
+		# Otherwise player may collide with this node multiple times while the animation finishes.
 		$CollisionShape2D.disabled = true
+		anim_player.play("collected")
 		await anim_player.animation_finished
 		queue_free()

--- a/Entities/Treasure/treasure.gd
+++ b/Entities/Treasure/treasure.gd
@@ -1,34 +1,25 @@
 extends Area2D
 
 @export var score_value := 5
-## If variance != 0, player will gain a score_value +- variance on collision.
+## Player will gain a score_value +- variance on collision.
 @export var variance := 0
 
-## If [should_randomize_appearance == true] then $AnimatedSprite2D will randomly choose one of the
-## animations listed here.
-@export var treasure_types : Array[String] = ["chest", "coin"]
-## If true, the treasure's appearance is randomized on ready. Options are listed in treasure_types.
-@export var should_randomize_appearance := true
-
-@onready var anim_player : AnimationPlayer = $AnimationPlayer
+@onready var collision_shape: CollisionShape2D = $CollisionShape2D
+@onready var anim_sprite: AnimatedSprite2D = $AnimatedSprite2D
+@onready var anim_player: AnimationPlayer = $AnimationPlayer
 
 
-func _ready():
-	if should_randomize_appearance:
-		var anim_sprite : AnimatedSprite2D = $AnimatedSprite2D
-		anim_sprite.animation = treasure_types[randi() % treasure_types.size()]
+func _ready() -> void:
+    var animations = anim_sprite.sprite_frames.get_animation_names()
+    anim_sprite.animation = animations[randi() % animations.size()]
 
 
-func _process(delta):
-	pass
-
-
-func _on_body_entered(body):
-	if body.has_method("score_up"):
-		body.score_up(score_value + randi_range(-variance, variance))
-		
-		# Otherwise player may collide with this node multiple times while the animation finishes.
-		$CollisionShape2D.disabled = true
-		anim_player.play("collected")
-		await anim_player.animation_finished
-		queue_free()
+func _on_body_entered(player: Player) -> void:
+    player.score_up(score_value + randi_range(-variance, variance))
+    
+    # Otherwise player may collide with this node multiple times while the animation finishes.
+    collision_shape.disabled = true
+    
+    anim_player.play("collected")
+    await anim_player.animation_finished
+    queue_free()

--- a/Entities/Treasure/treasure.gd
+++ b/Entities/Treasure/treasure.gd
@@ -1,17 +1,24 @@
-extends Node2D
+extends Area2D
 
 @export var score_value := 5
+## If variance is not 0, player will gain a score_value +- variance.
+@export var variance := 0
 
+@onready var anim_player : AnimationPlayer = $AnimationPlayer
 
 func _ready():
-    pass # Replace with function body.
+	pass # Replace with function body.
 
 
 func _process(delta):
-    pass
+	pass
 
 
 func _on_body_entered(body):
-    if body.has_method("score_up"):
-        body.score_up(score_value)
-    queue_free() # TODO: Disappear animation with AnimationPlayer
+	if body.has_method("score_up"):
+		body.score_up(score_value + randi_range(-variance, variance))
+		anim_player.play("collected")
+		# Otherwise player may collide multiple times while the animation finishes.
+		$CollisionShape2D.disabled = true
+		await anim_player.animation_finished
+		queue_free()

--- a/Entities/Treasure/treasure.tscn
+++ b/Entities/Treasure/treasure.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=8 format=3 uid="uid://dr57vkfcw5ply"]
+[gd_scene load_steps=9 format=3 uid="uid://dr57vkfcw5ply"]
 
 [ext_resource type="Script" path="res://Entities/Treasure/treasure.gd" id="1_34wjc"]
 [ext_resource type="Texture2D" uid="uid://csc8fnlnwjtn6" path="res://Assets/PNG/Ship parts/crew (1).png" id="2_j20kx"]
+[ext_resource type="Texture2D" uid="uid://x0u4ov4yap1w" path="res://Assets/PNG/Ship parts/crew (5).png" id="3_ijpue"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_43wbw"]
 
@@ -14,7 +15,18 @@ animations = [{
 "loop": true,
 "name": &"chest",
 "speed": 5.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": ExtResource("3_ijpue")
+}],
+"loop": true,
+"name": &"coin",
+"speed": 5.0
 }]
+
+[sub_resource type="Animation" id="Animation_hr2gu"]
+length = 0.001
 
 [sub_resource type="Animation" id="Animation_1yndv"]
 resource_name = "collected"
@@ -45,9 +57,6 @@ tracks/1/keys = {
 "values": [Vector2(1, 1), Vector2(2, 2)]
 }
 
-[sub_resource type="Animation" id="Animation_hr2gu"]
-length = 0.001
-
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_jevvr"]
 _data = {
 "RESET": SubResource("Animation_hr2gu"),
@@ -62,7 +71,7 @@ shape = SubResource("CircleShape2D_43wbw")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 sprite_frames = SubResource("SpriteFrames_fjsx3")
-animation = &"chest"
+animation = &"coin"
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 autoplay = "RESET"

--- a/Entities/Treasure/treasure.tscn
+++ b/Entities/Treasure/treasure.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=5 format=3 uid="uid://dr57vkfcw5ply"]
+[gd_scene load_steps=8 format=3 uid="uid://dr57vkfcw5ply"]
 
 [ext_resource type="Script" path="res://Entities/Treasure/treasure.gd" id="1_34wjc"]
 [ext_resource type="Texture2D" uid="uid://csc8fnlnwjtn6" path="res://Assets/PNG/Ship parts/crew (1).png" id="2_j20kx"]
@@ -16,6 +16,44 @@ animations = [{
 "speed": 5.0
 }]
 
+[sub_resource type="Animation" id="Animation_1yndv"]
+resource_name = "collected"
+length = 0.4
+step = 0.05
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("AnimatedSprite2D:self_modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.4),
+"transitions": PackedFloat32Array(1, 0.5),
+"update": 0,
+"values": [Color(1, 1, 1, 1), Color(1, 1, 1, 0.141176)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("AnimatedSprite2D:scale")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.4),
+"transitions": PackedFloat32Array(0.5, 25.1067),
+"update": 0,
+"values": [Vector2(1, 1), Vector2(2, 2)]
+}
+
+[sub_resource type="Animation" id="Animation_hr2gu"]
+length = 0.001
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_jevvr"]
+_data = {
+"RESET": SubResource("Animation_hr2gu"),
+"collected": SubResource("Animation_1yndv")
+}
+
 [node name="treasure" type="Area2D"]
 script = ExtResource("1_34wjc")
 
@@ -25,5 +63,11 @@ shape = SubResource("CircleShape2D_43wbw")
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 sprite_frames = SubResource("SpriteFrames_fjsx3")
 animation = &"chest"
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+autoplay = "RESET"
+libraries = {
+"": SubResource("AnimationLibrary_jevvr")
+}
 
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]

--- a/Entities/Treasure/treasure.tscn
+++ b/Entities/Treasure/treasure.tscn
@@ -63,7 +63,7 @@ _data = {
 "collected": SubResource("Animation_1yndv")
 }
 
-[node name="treasure" type="Area2D"]
+[node name="Treasure" type="Area2D"]
 script = ExtResource("1_34wjc")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]


### PR DESCRIPTION
Changes:
- Added small animation that plays when player collects treasure. TODO: Add sound effect as well. 
- Fixed small issue where treasure would queue_free on contact with any entity should they have collisions setup. 
- Added property variance to treasure. When set, treasure will increment the player's score by a random amount within the range of score_value +- variance. Of course, variance = 0 means no variance/randomness. 
If the above is unwanted, just say so and I'll remove it.