### PR TITLE
Adds credits

### DIFF
--- a/Scenes/StartMenu/Credits/credits.gd
+++ b/Scenes/StartMenu/Credits/credits.gd
@@ -1,0 +1,33 @@
+extends Control
+
+var credits_dict = JSON.parse_string(FileAccess.get_file_as_string("res://credits.json"))
+var credits_item = preload("res://Scenes/StartMenu/Credits/credits_item.tscn")
+
+@onready var credits_container = $CreditsContainer
+@onready var thanks_label = $ThanksLabel
+
+func _ready():
+	assert(credits_dict, "Credits not valid JSON formatted")
+
+	credits_dict.shuffle()
+
+	for contributor in credits_dict:
+		var contributor_item = credits_item.instantiate()
+		contributor_item.set_labels(contributor["Name"], contributor["Role"])
+		credits_container.add_child(contributor_item)
+	
+	remove_child(thanks_label)
+	credits_container.add_child(thanks_label)
+
+	credits_container.position.y += 200
+
+func _process(delta):
+	credits_container.position.y -= 1
+	if credits_container.position.y < credits_container.size.y * -1:
+		queue_free()
+
+
+func _on_gui_input(event):
+	if event is InputEventMouseMotion:
+		return
+	queue_free()

--- a/Scenes/StartMenu/Credits/credits.gd
+++ b/Scenes/StartMenu/Credits/credits.gd
@@ -1,16 +1,17 @@
 extends Control
 
 var credits_dict = JSON.parse_string(FileAccess.get_file_as_string("res://credits.json"))
-var credits_item = preload("res://Scenes/StartMenu/Credits/credits_item.tscn")
+var credits_item: PackedScene = preload("res://Scenes/StartMenu/Credits/credits_item.tscn")
 
 @onready var credits_container = $CreditsContainer
 @onready var thanks_label = $ThanksLabel
 
-func _ready():
-	assert(credits_dict, "Credits not valid JSON formatted")
 
+func _ready() -> void:
+	assert(credits_dict != null, "credits.json does not contain a valid JSON format")
+	
 	credits_dict.shuffle()
-
+	
 	for contributor in credits_dict:
 		var contributor_item = credits_item.instantiate()
 		contributor_item.set_labels(contributor["Name"], contributor["Role"])
@@ -18,16 +19,17 @@ func _ready():
 	
 	remove_child(thanks_label)
 	credits_container.add_child(thanks_label)
-
+	
 	credits_container.position.y += 200
 
-func _process(delta):
+
+func _process(_delta: float) -> void:
 	credits_container.position.y -= 1
 	if credits_container.position.y < credits_container.size.y * -1:
 		queue_free()
 
 
-func _on_gui_input(event):
+func _on_gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseMotion:
 		return
 	queue_free()

--- a/Scenes/StartMenu/Credits/credits.gd
+++ b/Scenes/StartMenu/Credits/credits.gd
@@ -1,7 +1,8 @@
 extends Control
 
 var credits_dict = JSON.parse_string(FileAccess.get_file_as_string("res://credits.json"))
-var credits_item: PackedScene = preload("res://Scenes/StartMenu/Credits/credits_item.tscn")
+var credits_item_scene: PackedScene = load("res://Scenes/StartMenu/Credits/credits_item.tscn")
+var start_menu_scene: PackedScene = load("res://Scenes/StartMenu/start_menu.tscn")
 
 @onready var credits_container = $CreditsContainer
 @onready var thanks_label = $ThanksLabel
@@ -13,7 +14,7 @@ func _ready() -> void:
 	credits_dict.shuffle()
 	
 	for contributor in credits_dict:
-		var contributor_item = credits_item.instantiate()
+		var contributor_item = credits_item_scene.instantiate()
 		contributor_item.set_labels(contributor["Name"], contributor["Role"])
 		credits_container.add_child(contributor_item)
 	
@@ -32,4 +33,4 @@ func _process(_delta: float) -> void:
 func _on_gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseMotion:
 		return
-	queue_free()
+	get_tree().change_scene_to_packed(start_menu_scene)

--- a/Scenes/StartMenu/Credits/credits.tscn
+++ b/Scenes/StartMenu/Credits/credits.tscn
@@ -51,7 +51,7 @@ vertical_alignment = 1
 
 [node name="HSeparator2" type="HSeparator" parent="CreditsContainer"]
 layout_mode = 2
-theme_override_constants/separation = 120
+theme_override_constants/separation = 80
 theme_override_styles/separator = SubResource("StyleBoxEmpty_ffub6")
 
 [node name="ThanksLabel" type="Label" parent="."]

--- a/Scenes/StartMenu/Credits/credits.tscn
+++ b/Scenes/StartMenu/Credits/credits.tscn
@@ -1,0 +1,65 @@
+[gd_scene load_steps=5 format=3 uid="uid://boggwsmqinlhu"]
+
+[ext_resource type="Script" path="res://Scenes/StartMenu/Credits/credits.gd" id="1_6kiqf"]
+[ext_resource type="Texture2D" uid="uid://cejpxsxr3r5ic" path="res://Scenes/StartMenu/logo.png" id="2_mgxpd"]
+[ext_resource type="Theme" uid="uid://cl5dwigu7j6fe" path="res://Themes/default_theme.tres" id="2_vmu60"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_ffub6"]
+
+[node name="Credits" type="Control"]
+layout_mode = 3
+anchors_preset = 0
+script = ExtResource("1_6kiqf")
+
+[node name="BackgroundColorRect" type="ColorRect" parent="."]
+layout_mode = 0
+offset_left = -129.0
+offset_top = -99.0
+offset_right = 1275.0
+offset_bottom = 759.0
+color = Color(0, 0, 0, 1)
+
+[node name="CreditsContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_right = 1153.0
+offset_bottom = 647.0
+grow_horizontal = 2
+alignment = 1
+
+[node name="TextureRect" type="TextureRect" parent="CreditsContainer"]
+layout_mode = 2
+size_flags_horizontal = 4
+texture = ExtResource("2_mgxpd")
+stretch_mode = 2
+
+[node name="HSeparator" type="HSeparator" parent="CreditsContainer"]
+layout_mode = 2
+theme_override_constants/separation = 120
+theme_override_styles/separator = SubResource("StyleBoxEmpty_ffub6")
+
+[node name="OrderLabel" type="Label" parent="CreditsContainer"]
+layout_mode = 2
+theme = ExtResource("2_vmu60")
+theme_override_colors/font_color = Color(0.654902, 0.654902, 0.654902, 1)
+theme_override_font_sizes/font_size = 48
+text = "Credited in Random Order:"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="HSeparator2" type="HSeparator" parent="CreditsContainer"]
+layout_mode = 2
+theme_override_constants/separation = 120
+theme_override_styles/separator = SubResource("StyleBoxEmpty_ffub6")
+
+[node name="ThanksLabel" type="Label" parent="."]
+layout_mode = 0
+theme = ExtResource("2_vmu60")
+theme_override_font_sizes/font_size = 64
+text = "Thank you for playing!"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[connection signal="gui_input" from="." to="." method="_on_gui_input"]

--- a/Scenes/StartMenu/Credits/credits_item.gd
+++ b/Scenes/StartMenu/Credits/credits_item.gd
@@ -1,0 +1,5 @@
+extends VBoxContainer
+
+func set_labels(_name, role):
+	$NameLabel.text = _name
+	$RoleLabel.text = role

--- a/Scenes/StartMenu/Credits/credits_item.gd
+++ b/Scenes/StartMenu/Credits/credits_item.gd
@@ -1,5 +1,5 @@
 extends VBoxContainer
 
-func set_labels(_name, role):
+func set_labels(_name: String, role: String) -> void:
 	$NameLabel.text = _name
 	$RoleLabel.text = role

--- a/Scenes/StartMenu/Credits/credits_item.tscn
+++ b/Scenes/StartMenu/Credits/credits_item.tscn
@@ -6,6 +6,8 @@
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_x3n5v"]
 
 [node name="CreditsItem" type="VBoxContainer"]
+offset_right = 390.0
+offset_bottom = 234.0
 alignment = 1
 script = ExtResource("1_iv8a7")
 
@@ -28,5 +30,5 @@ vertical_alignment = 1
 
 [node name="HSeparator" type="HSeparator" parent="."]
 layout_mode = 2
-theme_override_constants/separation = 120
+theme_override_constants/separation = 100
 theme_override_styles/separator = SubResource("StyleBoxEmpty_x3n5v")

--- a/Scenes/StartMenu/Credits/credits_item.tscn
+++ b/Scenes/StartMenu/Credits/credits_item.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=4 format=3 uid="uid://df7bmm1oupa4i"]
+
+[ext_resource type="Script" path="res://Scenes/StartMenu/Credits/credits_item.gd" id="1_iv8a7"]
+[ext_resource type="Theme" uid="uid://cl5dwigu7j6fe" path="res://Themes/default_theme.tres" id="2_go8e8"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_x3n5v"]
+
+[node name="CreditsItem" type="VBoxContainer"]
+alignment = 1
+script = ExtResource("1_iv8a7")
+
+[node name="NameLabel" type="Label" parent="."]
+layout_mode = 2
+theme = ExtResource("2_go8e8")
+theme_override_font_sizes/font_size = 64
+text = "Contributor Name"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="RoleLabel" type="Label" parent="."]
+layout_mode = 2
+theme = ExtResource("2_go8e8")
+theme_override_colors/font_color = Color(0.654902, 0.654902, 0.654902, 1)
+theme_override_font_sizes/font_size = 48
+text = "Contributor Role"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="HSeparator" type="HSeparator" parent="."]
+layout_mode = 2
+theme_override_constants/separation = 120
+theme_override_styles/separator = SubResource("StyleBoxEmpty_x3n5v")

--- a/Scenes/StartMenu/start_menu.gd
+++ b/Scenes/StartMenu/start_menu.gd
@@ -15,6 +15,6 @@ func _on_start_button_pressed() -> void:
 	queue_free()
 
 
-func _on_credits_button_pressed():
+func _on_credits_button_pressed() -> void:
 	var credits = CREDITS_SCENE.instantiate()
 	get_tree().root.add_child(credits)

--- a/Scenes/StartMenu/start_menu.gd
+++ b/Scenes/StartMenu/start_menu.gd
@@ -1,6 +1,7 @@
 extends Control
 
 @onready var GAME_SCENE: PackedScene = preload("res://Scenes/Game/game.tscn")
+@onready var CREDITS_SCENE: PackedScene = preload("res://Scenes/StartMenu/Credits/credits.tscn")
 
 
 func _enter_tree() -> void:
@@ -12,3 +13,8 @@ func _on_start_button_pressed() -> void:
 	get_tree().root.add_child(game)
 	game.start()
 	queue_free()
+
+
+func _on_credits_button_pressed():
+	var credits = CREDITS_SCENE.instantiate()
+	get_tree().root.add_child(credits)

--- a/Scenes/StartMenu/start_menu.gd
+++ b/Scenes/StartMenu/start_menu.gd
@@ -1,7 +1,7 @@
 extends Control
 
-@onready var GAME_SCENE: PackedScene = preload("res://Scenes/Game/game.tscn")
-@onready var CREDITS_SCENE: PackedScene = preload("res://Scenes/StartMenu/Credits/credits.tscn")
+var game_scene: PackedScene = load("res://Scenes/Game/game.tscn")
+var credits_scene: PackedScene = load("res://Scenes/StartMenu/Credits/credits.tscn")
 
 
 func _enter_tree() -> void:
@@ -9,12 +9,11 @@ func _enter_tree() -> void:
 
 
 func _on_start_button_pressed() -> void:
-	var game = GAME_SCENE.instantiate()
+	var game = game_scene.instantiate()
 	get_tree().root.add_child(game)
 	game.start()
 	queue_free()
 
 
 func _on_credits_button_pressed() -> void:
-	var credits = CREDITS_SCENE.instantiate()
-	get_tree().root.add_child(credits)
+	get_tree().change_scene_to_packed(credits_scene)

--- a/Scenes/StartMenu/start_menu.tscn
+++ b/Scenes/StartMenu/start_menu.tscn
@@ -42,4 +42,22 @@ theme = ExtResource("3_aap2y")
 theme_override_font_sizes/font_size = 48
 text = "Start Game!"
 
+[node name="CreditsButton" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = 434.0
+offset_top = -66.0
+offset_right = 560.0
+offset_bottom = -16.0
+grow_horizontal = 2
+grow_vertical = 0
+theme = ExtResource("3_aap2y")
+theme_override_font_sizes/font_size = 24
+text = "Credits"
+
 [connection signal="pressed" from="StartButton" to="." method="_on_start_button_pressed"]
+[connection signal="pressed" from="CreditsButton" to="." method="_on_credits_button_pressed"]

--- a/credits.json
+++ b/credits.json
@@ -1,18 +1,18 @@
 [
 	{
 		"Name":"Alec Tremblay",
-		"Role":"Programmer, Accreditations"
-	},
-	{
-		"Name":"Dion Tryban",
-		"Role":"Programmer"
-	},
-	{
-		"Name":"Whalen",
-		"Role":"Art"
+		"Role":"Programmer, Shader Artist"
 	},
 	{
 		"Name":"Casey W",
+		"Role":"Programmer"
+	},
+	{
+		"Name":"Chris Swezy",
+		"Role":"Designer, Programmer"
+	},
+	{
+		"Name":"Dion Tryban",
 		"Role":"Programmer"
 	},
 	{
@@ -24,7 +24,7 @@
 		"Role":"Programmer"
 	},
 	{
-		"Name":"Chris Swezy",
-		"Role":"Programmer"
+		"Name":"Whalen",
+		"Role":"Artist"
 	}
 ]

--- a/credits.json
+++ b/credits.json
@@ -1,0 +1,30 @@
+[
+	{
+		"Name":"Alec Tremblay",
+		"Role":"Programmer, Accreditations"
+	},
+	{
+		"Name":"Dion Tryban",
+		"Role":"Programmer"
+	},
+	{
+		"Name":"Whalen",
+		"Role":"Art"
+	},
+	{
+		"Name":"Casey W",
+		"Role":"Programmer"
+	},
+	{
+		"Name":"Joseph A de Souza Lira",
+		"Role":"Programmer"
+	},
+	{
+		"Name":"Jake",
+		"Role":"Programmer"
+	},
+	{
+		"Name":"Chris Swezy",
+		"Role":"Programmer"
+	}
+]


### PR DESCRIPTION
Proposes simple credits implementation from a JSON file for issue #36. Contributors are randomly shuffled, a credits_item control scene is created for each contributor, then added to the credits scene, which scrolls through the whole list and then dequeues itself.